### PR TITLE
BNO055 for victoria_base

### DIFF
--- a/launch/victoria_base.launch
+++ b/launch/victoria_base.launch
@@ -21,12 +21,4 @@
     <!-- Launch victoria_base to republish messages from platform -->
     <node pkg="victoria_base" type="victoria_base.py" name="victoria_base_node" output="screen"/>
 
-    <!-- Launch IMU filter -->
-    <node pkg="imu_complementary_filter" type="complementary_filter_node" name="complementary_filter_gain_node" output="screen">
-        <param name="do_bias_estimation" value="true"/>
-        <param name="do_adaptive_gain" value="true"/>
-        <param name="use_mag" value="true"/>
-        <param name="gain_acc" value="0.01"/>
-        <param name="gain_mag" value="0.01"/>
-    </node>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,6 @@
     <depend>sensor_msgs</depend>
     <depend>victoria_nav_msgs</depend>
     <depend>victoria_sensor_msgs</depend>
-    <exec_depend>imu_complementary_filter</exec_depend>
     <!-- The export tag contains other, unspecified, tags -->
     <export>
         <!-- Other tools can request additional information be placed here -->

--- a/scripts/victoria_base.py
+++ b/scripts/victoria_base.py
@@ -68,7 +68,7 @@ def callbackImu(msg):
     q = np.array([msg.quaternion.x, msg.quaternion.y, msg.quaternion.z, msg.quaternion.w])
     q = normalize(q)
     euler = tf.transformations.euler_from_quaternion(q)
-    q = tf.transformations.quaternion_from_euler(euler[0], euler[1], euler[2] - math.pi)
+    q = tf.transformations.quaternion_from_euler(-(euler[0] + math.pi / 2), euler[1], euler[2] - math.pi)
     imu_msg.orientation.x = q[0]
     imu_msg.orientation.y = q[1]
     imu_msg.orientation.z = q[2]
@@ -77,9 +77,9 @@ def callbackImu(msg):
     rospy.loginfo("euler[0] = %s, euler[1] = %s, euler = [2] = %s",
             str(euler_new[0]), str(euler_new[1]), str(euler_new[2]))
 
-    imu_msg.orientation_covariance = [0.09,    0,    0, \
-                                         0, 0.09,    0, \
-                                         0,    0, 0.09]
+    imu_msg.orientation_covariance = [0.9,    0,    0, \
+                                         0, 0.9,    0, \
+                                         0,    0, 0.9]
 
     imu_msg.angular_velocity = msg.gyro
     imu_msg.angular_velocity_covariance = [0.9,   0,   0, \
@@ -136,12 +136,12 @@ def callbackOdom(msg):
         odom_msg.pose.pose.orientation.y = q[1]
         odom_msg.pose.pose.orientation.z = q[2]
         odom_msg.pose.pose.orientation.w = q[3]
-        odom_msg.pose.covariance = [4, 0, 0,   0,   0,   0, \
-                                    0, 4, 0,   0,   0,   0, \
-                                    0, 0, 4,   0,   0,   0, \
-                                    0, 0, 0, 0.1,   0,   0, \
-                                    0, 0, 0,   0, 0.1,   0, \
-                                    0, 0, 0,   0,   0, 0.1]
+        odom_msg.pose.covariance = [8, 0, 0,   0,   0,   0, \
+                                    0, 8, 0,   0,   0,   0, \
+                                    0, 0, 8,   0,   0,   0, \
+                                    0, 0, 0, 1,   0,   0, \
+                                    0, 0, 0,   0, 1,   0, \
+                                    0, 0, 0,   0,   0, 1]
 
         odom_msg.twist.twist.linear.x = msg.twist.vx
         odom_msg.twist.twist.linear.y = msg.twist.vy
@@ -150,12 +150,12 @@ def callbackOdom(msg):
         odom_msg.twist.twist.angular.x = 0
         odom_msg.twist.twist.angular.y = 0
         odom_msg.twist.twist.angular.z = msg.twist.vtheta
-        odom_msg.twist.covariance = [0.1,   0,   0,    0,    0,    0, \
-                                       0, 0.1,   0,    0,    0,    0, \
-                                       0,   0, 0.1,    0,    0,    0, \
-                                       0,   0,   0, 0.03,    0,    0, \
-                                       0,   0,   0,    0, 0.03,    0, \
-                                       0,   0,   0,    0,    0, 0.03]
+        odom_msg.twist.covariance = [0.5,   0,   0,    0,    0,    0, \
+                                       0, 0.5,   0,    0,    0,    0, \
+                                       0,   0, 0.5,    0,    0,    0, \
+                                       0,   0,   0, 1,    0,    0, \
+                                       0,   0,   0,    0, 1,    0, \
+                                       0,   0,   0,    0,    0, 1]
 
 
         odom_pub.publish(odom_msg)


### PR DESCRIPTION
Changed the base node to publish quaternion from new imu and to no longer launch the complementary filter node.
Removed dep on imu_complementary_filter.
Added ros_info to euler angle version of quaternion.
Republishing BNO055 quaternion, with calibration flag and converting east to west.